### PR TITLE
Register editable custom field ethereum address

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -7,6 +7,8 @@ enabled_site_setting :discourse_ethereum_enabled
 register_asset "stylesheets/common.scss"
 register_asset "stylesheets/mobile.scss", :mobile
 
+register_editable_user_custom_field :ethereum_address
+
 require_relative "lib/ethereum"
 
 after_initialize {


### PR DESCRIPTION
As per https://github.com/Ebsy/discourse-nationalflags/pull/3 and
https://meta.discourse.org/t/add-a-custom-per-user-setting-in-a-plugin/94048

Possibly fixes https://github.com/santiment/discourse-ethereum/issues/6, not tested still